### PR TITLE
Drop ring dependency and update RustCrypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 lazy_static = "1.4.0"
 yasna = { version = "0.3.1" }
-getrandom = "0.1.14"
-block-modes = "0.5.0"
-hmac = "0.8.0"
+getrandom = "0.2.0"
+block-modes = "0.6.1"
+hmac = "0.9.0"
 sha-1 = "0.9.0"
-rc2 = "0.4.0"
-des = "0.4.0"
+rc2 = "0.5.0"
+des = "0.5.0"
 
 [dev-dependencies]
 hex = "0.4.2"
-hex-literal = "0.2.1"
+hex-literal = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ lazy_static = "1.4.0"
 yasna = { version = "0.3.1" }
 getrandom = "0.1.14"
 block-modes = "0.4.0"
-block-cipher-trait = "0.7.0"
 hmac = "0.8.0"
 sha-1 = "0.9.0"
 rc2 = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ license = "MIT OR Apache-2.0"
 lazy_static = "1.4.0"
 yasna = { version = "0.3.1" }
 getrandom = "0.1.14"
-block-modes = "0.3.3"
-block-cipher-trait = "0.6.2"
-hmac = "0.7.1"
-sha-1 = "0.8.1"
-rc2 = "0.3.0"
-des = "0.3.0"
+block-modes = "0.4.0"
+block-cipher-trait = "0.7.0"
+hmac = "0.8.0"
+sha-1 = "0.9.0"
+rc2 = "0.4.0"
+des = "0.4.0"
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 lazy_static = "1.4.0"
 yasna = { version = "0.3.1" }
 getrandom = "0.1.14"
-block-modes = "0.4.0"
+block-modes = "0.5.0"
 hmac = "0.8.0"
 sha-1 = "0.9.0"
 rc2 = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ yasna = { version = "0.3.1" }
 ring = "0.16.12"
 block-modes = "0.3.3"
 block-cipher-trait = "0.6.2"
+hmac = "0.7.1"
+sha-1 = "0.8.1"
 rc2 = "0.3.0"
 des = "0.3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 lazy_static = "1.4.0"
 yasna = { version = "0.3.1" }
-ring = "0.16.12"
+getrandom = "0.1.14"
 block-modes = "0.3.3"
 block-cipher-trait = "0.6.2"
 hmac = "0.7.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,13 @@
 //!
 
 use lazy_static::lazy_static;
-use ring::digest::Digest;
-use ring::hmac;
 use ring::rand::{self, SecureRandom};
 use yasna::{models::ObjectIdentifier, ASN1Error, ASN1ErrorKind, BERReader, DERWriter, Tag};
+
+use hmac::{Mac, Hmac};
+use sha1::{Sha1, Digest};
+
+type HmacSha1 = Hmac<Sha1>;
 
 fn as_oid(s: &'static [u64]) -> ObjectIdentifier {
     ObjectIdentifier::from_slice(s)
@@ -41,9 +44,10 @@ lazy_static! {
 
 const ITERATIONS: u64 = 2048;
 
-fn sha1(bytes: &[u8]) -> Digest {
-    use ring::digest::*;
-    digest(&SHA1_FOR_LEGACY_USE_ONLY, bytes)
+fn sha1(bytes: &[u8]) -> Vec<u8> {
+    let mut hasher = Sha1::new();
+    hasher.input(bytes);
+    hasher.result().to_vec()
 }
 
 #[derive(Debug, Clone)]
@@ -377,15 +381,17 @@ impl MacData {
     pub fn verify_mac(&self, data: &[u8], password: &[u8]) -> bool {
         debug_assert_eq!(self.mac.digest_algorithm, AlgorithmIdentifier::Sha1);
         let key = pbepkcs12sha1(password, &self.salt, self.iterations as u64, 3, 20);
-        let m = hmac::Key::new(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, &key);
-        hmac::verify(&m, data, &self.mac.digest).is_ok()
+        let mut mac = HmacSha1::new_varkey(&key).unwrap();
+        mac.input(data);
+        mac.verify(&self.mac.digest).is_ok()
     }
 
     pub fn new(data: &[u8], password: &[u8]) -> MacData {
         let salt = rand().unwrap();
         let key = pbepkcs12sha1(password, &salt, ITERATIONS, 3, 20);
-        let m = hmac::Key::new(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, &key);
-        let digest = hmac::sign(&m, data).as_ref().to_owned();
+        let mut mac = HmacSha1::new_varkey(&key).unwrap();
+        mac.input(data);
+        let digest = mac.result().code().to_vec();
         MacData {
             mac: DigestInfo {
                 digest_algorithm: AlgorithmIdentifier::Sha1,
@@ -445,7 +451,7 @@ impl PFX {
             encrypted_data,
         });
         let friendly_name = PKCS12Attribute::FriendlyName(name.to_owned());
-        let local_key_id = PKCS12Attribute::LocalKeyId(sha1(cert_der).as_ref().to_owned());
+        let local_key_id = PKCS12Attribute::LocalKeyId(sha1(cert_der));
         let key_bag = SafeBag {
             bag: key_bag_inner,
             attributes: vec![friendly_name.clone(), local_key_id.clone()],
@@ -588,7 +594,7 @@ impl PFX {
 fn pbepkcs12sha1core(d: &[u8], i: &[u8], a: &mut Vec<u8>, iterations: u64) -> Vec<u8> {
     let mut ai: Vec<u8> = d.iter().chain(i.iter()).cloned().collect();
     for _ in 0..iterations {
-        ai = sha1(&ai).as_ref().to_owned();
+        ai = sha1(&ai);
     }
     a.append(&mut ai.clone());
     ai

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 
 use lazy_static::lazy_static;
-use ring::rand::{self, SecureRandom};
+use getrandom::getrandom;
 use yasna::{models::ObjectIdentifier, ASN1Error, ASN1ErrorKind, BERReader, DERWriter, Tag};
 
 use hmac::{Mac, Hmac};
@@ -39,7 +39,6 @@ lazy_static! {
     static ref OID_SECRET_BAG: ObjectIdentifier = as_oid(&[1, 2, 840, 113_549, 1, 12, 10, 1, 5]);
     static ref OID_SAFE_CONTENTS_BAG: ObjectIdentifier =
         as_oid(&[1, 2, 840, 113_549, 1, 12, 10, 1, 6]);
-    static ref RAND: rand::SystemRandom = rand::SystemRandom::new();
 }
 
 const ITERATIONS: u64 = 2048;
@@ -405,9 +404,11 @@ impl MacData {
 
 fn rand() -> Option<[u8; 8]> {
     let mut buf = [0u8; 8];
-    let rng = rand::SystemRandom::new();
-    rng.fill(&mut buf).ok()?;
-    Some(buf)
+    if getrandom(&mut buf).is_ok() {
+        Some(buf)
+    } else {
+        None
+    }
 }
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,12 @@
 //!
 //!
 
-use lazy_static::lazy_static;
 use getrandom::getrandom;
+use lazy_static::lazy_static;
 use yasna::{models::ObjectIdentifier, ASN1Error, ASN1ErrorKind, BERReader, DERWriter, Tag};
 
-use hmac::{Mac, Hmac, NewMac};
-use sha1::{Sha1, Digest};
+use hmac::{Hmac, Mac, NewMac};
+use sha1::{Digest, Sha1};
 
 type HmacSha1 = Hmac<Sha1>;
 


### PR DESCRIPTION
Since RustCrypto is used for most things, switch the remaining ones and drop the ring dependency