### PR TITLE
update to cipher 0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ version = "^0.1"
 features = ["block-padding"]
 
 [dependencies.cipher]
-version = "^0.4.1"
+version = "^0.4.2"
 features = ["alloc", "block-padding"]
 
 [dependencies.yasna]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -657,7 +657,7 @@ fn pbe_with_sha1_and40_bit_rc2_cbc(
     let iv = pbepkcs12sha1(password, salt, iterations, 2, 8);
 
     let rc2 = Rc2Cbc::new_from_slices(&dk, &iv).ok()?;
-    rc2.decrypt_padded_vec::<Pkcs7>(data).ok()
+    rc2.decrypt_padded_vec_mut::<Pkcs7>(data).ok()
 }
 
 fn pbe_with_sha1_and40_bit_rc2_cbc_encrypt(
@@ -697,7 +697,7 @@ fn pbe_with_sha_and3_key_triple_des_cbc(
     let iv = pbepkcs12sha1(password, salt, iterations, 2, 8);
 
     let tdes = TDesCbc::new_from_slices(&dk, &iv).ok()?;
-    tdes.decrypt_padded_vec::<Pkcs7>(data).ok()
+    tdes.decrypt_padded_vec_mut::<Pkcs7>(data).ok()
 }
 
 fn pbe_with_sha_and3_key_triple_des_cbc_encrypt(


### PR DESCRIPTION
cipher 0.4.1 was yanked, and 0.4.2 was published [with breaking changes](https://github.com/RustCrypto/traits/pull/941). 
Maybe it would be nice to yank 0.6.2 and republish with this?