### PR TITLE
add pkcs5PBES2 encryption scheme whith PKDF2 and AES

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,15 @@ rust-version = "1.56.0"
 
 [dependencies]
 des = "^0.8"
+aes = "^0.8"
 getrandom = "^0.2"
 hmac = "^0.12"
 lazy_static = "^1.4"
 rc2 = "^0.8"
 sha1 = "^0.10"
+pbkdf2 = {version = "0.11.0" }
+password-hash = {version = "0.4.0"}
+block-padding = "0.3.2"
 
 [dependencies.cbc]
 version = "^0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = "^1.4"
 rc2 = "^0.8"
 sha1 = "^0.10"
 aes = { version = "0.8"}
-pbkdf2 = {version = "0.11.0" }
+pbkdf2 = {version = "0.11.0", features = ["sha1"] }
 password-hash = {version = "0.4.0"}
 block-padding = "0.3.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ rust-version = "1.56.0"
 
 [dependencies]
 des = "^0.8"
-aes = "^0.8"
 getrandom = "^0.2"
 hmac = "^0.12"
 lazy_static = "^1.4"
 rc2 = "^0.8"
 sha1 = "^0.10"
+aes = { version = "0.8"}
 pbkdf2 = {version = "0.11.0" }
 password-hash = {version = "0.4.0"}
 block-padding = "0.3.2"


### PR DESCRIPTION
I had to change form `[u8]` to `&str` for the password to keep a consistent API.

Support for other hash (sha3,...) and cipher (DES, ...) can be easly added  in the `Pkcs5Pbes2Params impl` and in the `pbe_pkcs5_scheme_2..` function

I also provide pkcs5 encrypting function, but for now the selection of the  encryption algorithm  for writing is hardcoded
   
