### PR TITLE
Parse PKCS12 using BER encoding rules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,7 +494,7 @@ impl PFX {
     }
 
     pub fn parse(bytes: &[u8]) -> Result<PFX, ASN1Error> {
-        yasna::parse_der(bytes, |r| {
+        yasna::parse_ber(bytes, |r| {
             r.read_sequence(|r| {
                 let version = r.next().read_u8()?;
                 let auth_safe = ContentInfo::parse(r.next())?;
@@ -529,7 +529,7 @@ impl PFX {
             .data(&password)
             .ok_or_else(|| ASN1Error::new(ASN1ErrorKind::Invalid))?;
 
-        let contents = yasna::parse_der(&data, |r| r.collect_sequence_of(ContentInfo::parse))?;
+        let contents = yasna::parse_ber(&data, |r| r.collect_sequence_of(ContentInfo::parse))?;
 
         let mut result = vec![];
         for content in contents.iter() {
@@ -537,7 +537,7 @@ impl PFX {
                 .data(&password)
                 .ok_or_else(|| ASN1Error::new(ASN1ErrorKind::Invalid))?;
 
-            let safe_bags = yasna::parse_der(&data, |r| r.collect_sequence_of(SafeBag::parse))?;
+            let safe_bags = yasna::parse_ber(&data, |r| r.collect_sequence_of(SafeBag::parse))?;
 
             for safe_bag in safe_bags.iter() {
                 result.push(safe_bag.to_owned())


### PR DESCRIPTION
According to [rfc7292](https://www.rfc-editor.org/rfc/rfc7292), chapter 4.1, 5.1 and Appendix A, the BER-encoding rules should be used.
Currently p12 decodes PKCS12 using DER encoding. Some of  the PKCS12 files, for example produced by Java keytool, do not conform to DER encoding, namely when encoding the SET OF sequence, which is not sorted, resulted in `yasna` parser returning an error.

Example:
```text
    0:d=0  hl=4 l=1395 cons: SEQUENCE          
    4:d=1  hl=4 l=1391 cons:  SEQUENCE          
    8:d=2  hl=2 l=  11 prim:   OBJECT            :pkcs8ShroudedKeyBag
   21:d=2  hl=4 l=1274 cons:   cont [ 0 ]        
   25:d=3  hl=4 l=1270 cons:    SEQUENCE          
   29:d=4  hl=2 l=  40 cons:     SEQUENCE          
   31:d=5  hl=2 l=  10 prim:      OBJECT            :pbeWithSHA1And3-KeyTripleDES-CBC
   43:d=5  hl=2 l=  26 cons:      SEQUENCE          
   45:d=6  hl=2 l=  20 prim:       OCTET STRING      [HEX DUMP]:xxxx
   67:d=6  hl=2 l=   2 prim:       INTEGER           :0400
   71:d=4  hl=4 l=1224 prim:     OCTET STRING      [HEX DUMP]:xxxx
 1299:d=2  hl=2 l=  98 cons:   SET               
 1301:d=3  hl=2 l=  61 cons:    SEQUENCE          
 1303:d=4  hl=2 l=   9 prim:     OBJECT            :friendlyName
 1314:d=4  hl=2 l=  48 cons:     SET               
 1316:d=5  hl=2 l=  46 prim:      BMPSTRING         
 1364:d=3  hl=2 l=  33 cons:    SEQUENCE          
 1366:d=4  hl=2 l=   9 prim:     OBJECT            :localKeyID
 1377:d=4  hl=2 l=  20 cons:     SET               
 1379:d=5  hl=2 l=  18 prim:      OCTET STRING      :Time 1502529450494
```
The last SET of attributes is not sorted according to ascending lexicographic order as defined by DER rules.
This PR just changes the encoding rules to BER.
