### PR TITLE
Fix edge cases

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,7 +360,7 @@ impl MacData {
         r.read_sequence(|r| {
             let mac = DigestInfo::parse(r.next())?;
             let salt = r.next().read_bytes()?;
-            let iterations = r.next().read_u32()?;
+            let iterations = r.read_optional(|r| r.read_u32())?.unwrap_or(1);
             Ok(MacData {
                 mac,
                 salt,


### PR DESCRIPTION
I've encountered problems with PKCS12 files generated by OpenSSL PKCS12_create function. I've checked [go-pkcs12](https://github.com/SSLMate/go-pkcs12) implementation and was able to solve them.

1) MacData::iterations (last 4 bytes of the file) are missing if set to default, [should be treated as iterations == 1](https://github.com/SSLMate/go-pkcs12/blob/a23dd40d71e2f5498281f7f86bec59c39447b1bc/pkcs12.go#L547)

2) If password is empty [0, 0] bmp_string doesn't work. Empty slice works well. [It seems it depends on implementation.](https://github.com/SSLMate/go-pkcs12/blob/a23dd40d71e2f5498281f7f86bec59c39447b1bc/pkcs12.go#L547)